### PR TITLE
check with SCVMM for VMs with the same name

### DIFF
--- a/internal/controllers/helper_winrmcommand.go
+++ b/internal/controllers/helper_winrmcommand.go
@@ -67,7 +67,6 @@ type VMResult struct {
 	CreationTime         metav1.Time
 	ModifiedTime         metav1.Time
 	Result               string
-	VMIDs                []string // for getVMIDsByName()'s benefit
 }
 
 // GetError Implement GetError() for VMResult so it implements WinrmErrorResult
@@ -80,6 +79,15 @@ type VMSpecResult struct {
 	Error        string
 	ScriptErrors string
 	Message      string
+}
+
+type VMIDsResult struct {
+	Error string
+	VMIDs []string
+}
+
+func (V VMIDsResult) GetError() string {
+	return V.Error
 }
 
 type ScriptError struct {

--- a/internal/controllers/helper_winrmcommand.go
+++ b/internal/controllers/helper_winrmcommand.go
@@ -63,6 +63,7 @@ type VMResult struct {
 	CreationTime         metav1.Time
 	ModifiedTime         metav1.Time
 	Result               string
+	VMIDs                []string // for getVMIDsByName()'s benefit
 }
 
 type VMSpecResult struct {

--- a/internal/controllers/scvmmmachine_controller.go
+++ b/internal/controllers/scvmmmachine_controller.go
@@ -274,7 +274,7 @@ func (r *ScvmmMachineReconciler) reconcileNormal(ctx context.Context, patchHelpe
 		if (scvmmMachine.Spec.Tag != "" && vm.Tag != scvmmMachine.Spec.Tag) || !equalStringMap(scvmmMachine.Spec.CustomProperty, vm.CustomProperty) {
 			return r.setVMProperties(ctx, patchHelper, scvmmMachine)
 		}
-		return r.startVM(ctx, patchHelper, cluster, machine, provider, scvmmMachine)
+		return r.startVM(ctx, patchHelper, provider, scvmmMachine)
 	}
 	// Support changing properties or tags
 	if (scvmmMachine.Spec.Tag != "" && vm.Tag != scvmmMachine.Spec.Tag) || !equalStringMap(scvmmMachine.Spec.CustomProperty, vm.CustomProperty) {
@@ -547,7 +547,7 @@ func (r *ScvmmMachineReconciler) addCloudInitToVM(ctx context.Context, patchHelp
 	return r.patchReasonCondition(ctx, patchHelper, scvmmMachine, 10, nil, VmCreated, VmCreatingReason, "Adding ISO to VM %s", vm.Name)
 }
 
-func (r *ScvmmMachineReconciler) startVM(ctx context.Context, patchHelper *patch.Helper, cluster *clusterv1.Cluster, machine *clusterv1.Machine, provider *infrav1.ScvmmProviderSpec, scvmmMachine *infrav1.ScvmmMachine) (ctrl.Result, error) {
+func (r *ScvmmMachineReconciler) startVM(ctx context.Context, patchHelper *patch.Helper, provider *infrav1.ScvmmProviderSpec, scvmmMachine *infrav1.ScvmmMachine) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	// Add adcomputer here, because we now know the vmname will not change
 	// (a VM with the cloud-init iso connected is prio 1 in vmname clash resolution)

--- a/internal/controllers/scvmmmachine_controller.go
+++ b/internal/controllers/scvmmmachine_controller.go
@@ -341,7 +341,7 @@ func (r *ScvmmMachineReconciler) createVM(ctx context.Context, patchHelper *patc
 				return r.patchReasonCondition(ctx, patchHelper, scvmmMachine, 0, err, VmCreated, VmFailedReason, "Failed to check if VMName already exists in SCVMM")
 			}
 			if len(vmIdsByName) > 0 {
-				return r.patchReasonCondition(ctx, patchHelper, scvmmMachine, 0, nil, VmCreated, VmFailedReason, "VMName already exists in SCVMM, cannot use it")
+				return r.patchReasonCondition(ctx, patchHelper, scvmmMachine, 0, nil, VmCreated, VmFailedReason, fmt.Sprintf("VMName already exists in SCVMM, cannot use it; VMName: '%s', VMIDs: '%s'", vmName, strings.Join(vmIdsByName, ", ")))
 			}
 			scvmmMachine.Spec.VMName = vmName
 			return r.patchReasonCondition(ctx, patchHelper, scvmmMachine, 0, nil, VmCreated, VmCreatingReason, "Set VMName %s", vmName)

--- a/internal/controllers/scvmmmachine_controller.go
+++ b/internal/controllers/scvmmmachine_controller.go
@@ -316,6 +316,15 @@ func (r *ScvmmMachineReconciler) getVM(ctx context.Context, scvmmMachine *infrav
 	return vm, nil
 }
 
+func (r *ScvmmMachineReconciler) getVMIDsByName(ctx context.Context, providerRef *infrav1.ScvmmProviderReference, VMName string) ([]string, error) {
+	log := ctrl.LoggerFrom(ctx)
+	result, err := sendWinrmCommand(log, providerRef, "GetVMIDsByName -VMName '%s'", escapeSingleQuotes(VMName))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get VMIDs by name %s", VMName)
+	}
+	return result.VMIDs, nil
+}
+
 func (r *ScvmmMachineReconciler) createVM(ctx context.Context, patchHelper *patch.Helper, scvmmMachine *infrav1.ScvmmMachine) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	spec := scvmmMachine.Spec

--- a/internal/controllers/scvmmmachine_controller.go
+++ b/internal/controllers/scvmmmachine_controller.go
@@ -318,7 +318,7 @@ func (r *ScvmmMachineReconciler) getVM(ctx context.Context, scvmmMachine *infrav
 
 func (r *ScvmmMachineReconciler) getVMIDsByName(ctx context.Context, providerRef *infrav1.ScvmmProviderReference, VMName string) ([]string, error) {
 	log := ctrl.LoggerFrom(ctx)
-	result, err := sendWinrmCommand(log, providerRef, "GetVMIDsByName -VMName '%s'", escapeSingleQuotes(VMName))
+	result, err := sendWinrmCommandWithErrorResult[VMIDsResult](log, providerRef, "GetVMIDsByName -VMName '%s'", escapeSingleQuotes(VMName))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get VMIDs by name %s", VMName)
 	}

--- a/scripts/GetVMIDsByName.ps1
+++ b/scripts/GetVMIDsByName.ps1
@@ -1,15 +1,17 @@
 param([string]$vmName)
+try {
+    # Get all VMs with the specified name; SCVMM will return a list if there is more than one
+    $vms = Get-SCVirtualMachine -Name $vmName
+    $vmIds = @()
 
-# Get all VMs with the specified name; SCVMM will return a list if there are more than one
-$vms = Get-SCVirtualMachine -Name $vmName
-$vmIds = @()
-
-# Check if any VMs were returned and collect their IDs
-if ($vms) {
-    foreach ($vm in $vms) {
-        $vmIds += $vm.ID
+    # Check if any VMs were returned and collect their IDs
+    if ($vms) {
+        foreach ($vm in $vms) {
+            $vmIds += $vm.ID
+        }
     }
-}
 
-# VMIDs ([]string) member was added to VMResult so this can use the same invoke/marshall logic as other scripts
-@{ VMIDs = $vmIds } | ConvertTo-Json
+    @{ VMIDs = $vmIds } | ConvertTo-Json -Compress
+} catch {
+    ErrorToJson 'Get VMIDs by VMName' $_
+}

--- a/scripts/GetVMIDsByName.ps1
+++ b/scripts/GetVMIDsByName.ps1
@@ -1,0 +1,15 @@
+param([string]$vmName)
+
+# Get all VMs with the specified name; SCVMM will return a list if there are more than one
+$vms = Get-SCVirtualMachine -Name $vmName
+$vmIds = @()
+
+# Check if any VMs were returned and collect their IDs
+if ($vms) {
+    foreach ($vm in $vms) {
+        $vmIds += $vm.ID
+    }
+}
+
+# VMIDs ([]string) member was added to VMResult so this can use the same invoke/marshall logic as other scripts
+@{ VMIDs = $vmIds } | ConvertTo-Json


### PR DESCRIPTION
This implements a triple-check to ensure VM names are not duplicated in SCVMM. Once during namepool allocation, twice before creating the VM, and thrice before adding to ActiveDirectory/Starting the VM. In the process, I've fixed a few compiler warnings and refactored `sendWinrmCommand` using Generics and introduced a common  `WinrmErrorResult` interface.

---

#### squash some warnings

- helper_winrmcommand:
  - catch & log winrm.DirectCommand's Close() errors if any
  - ioutil.ReadFile() -> os.ReadFile()
- scvmmmachine:
  - remove unused parameters (cluster, machine) from startVM()

#### introduce `getVMIDsByName` by abusing the preexisting `VMResult` with a VMIDs []string

- GetVMIDsByName.ps1: Get-SCVirtualMachine returns an iterable if more than one found, supposedly.

#### ScvmmMachine: when allocating from the namepool, check with SCVMM for VMs with the same name, and skip if so

- log the IDs of the VMs that match the name when skipping

#### ScvmmMachine: double-check the VMName is unique before creating a VM

- generateVMName() has already checked/skipped the ones that already exist, but double-check, as the name might have been checked in a distant past and be already owned
  - in this case, the creation will fail, which is still better than duplicating VM names

#### include the VMIDs of preexisting VMs with the same name when erroring out the double check

#### ScvmmMachine: triple-check VMName is unique before adding to AD / starting VM

#### winRM: refactor `sendWinrmCommand(...)(VMResult)` into generic `sendWinrmCommandWithErrorResult[T any](...)(T)`

- this does a trick to get to the GetError() member, needs further refactoring

#### winRM: further refactor; introduce WinrmErrorResult with GetError(), implemented by VMResult (don't touch VMSpec)

- the good: no more tricks getting at the (PowerShell-provided) Error string
- the bad: ...?
- the ugly: each struct (VMResult/...) needs boilerplate/explicit implementation of GetError()

#### winRM: de-piggyback VMIDs member from VMResult; introduce VMIDsResult

- wrap PS in try/catch and ErrorToJson

---

I will PR the winRM-related refactoring of "winRM: refactor sendWinrmSpecCommand and implement VMSpecResult's GetError()" separately, as that seems to cause trouble (any winRM invocation after VMSpec-related commands hang). 