### PR TITLE
Skip machine reconciliation for Paused clusters or machines

### DIFF
--- a/internal/controllers/scvmmmachine_controller.go
+++ b/internal/controllers/scvmmmachine_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"strings"
 	"time"
 
@@ -211,6 +212,12 @@ func (r *ScvmmMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			log.Error(err, "Failed to patch scvmmMachine", "scvmmmachine", scvmmMachine)
 			return ctrl.Result{}, err
 		}
+	}
+
+	// Hard skip if cluster exists and is paused, or if the clusterless scvmmmachine has a paused annotation.
+	if (cluster != nil && annotations.IsPaused(cluster, machine)) || (annotations.HasPaused(scvmmMachine)) {
+		log.Info("Cluster is Paused or ScvmmMachine has paused Annotation, skipping reconciliation")
+		return ctrl.Result{}, nil
 	}
 
 	// Handle non-deleted machines


### PR DESCRIPTION
I've still to demonstrate why the already in-place predicates fail to prevent it in the first place; my guess is because we can have Bootstrap-machines (clusterless) it ends up skipping too eagerly. 